### PR TITLE
Pull fixes from MarSoft fork

### DIFF
--- a/sanic_cors/decorator.py
+++ b/sanic_cors/decorator.py
@@ -131,7 +131,7 @@ def cross_origin(app, *args, **kwargs):
                 resp = response.HTTPResponse()
             else:
                 resp = f(req, *args, **kwargs)
-                if asyncio.iscoroutine(resp):
+                while asyncio.iscoroutine(resp):
                     resp = await resp
 
             set_cors_headers(req, resp, options)

--- a/sanic_cors/decorator.py
+++ b/sanic_cors/decorator.py
@@ -122,7 +122,7 @@ def cross_origin(app, *args, **kwargs):
         #     f.required_methods.add('OPTIONS')
         #     f.provide_automatic_options = False
 
-        def wrapped_function(req, *args, **kwargs):
+        async def wrapped_function(req, *args, **kwargs):
             # Handle setting of Sanic-Cors parameters
             options = get_cors_options(app, _options)
 
@@ -130,6 +130,8 @@ def cross_origin(app, *args, **kwargs):
                 resp = response.HTTPResponse()
             else:
                 resp = f(req, *args, **kwargs)
+                if asyncio.iscoroutine(resp):
+                    resp = await resp
 
             set_cors_headers(req, resp, options)
             req.headers[SANIC_CORS_EVALUATED] = "1"

--- a/sanic_cors/decorator.py
+++ b/sanic_cors/decorator.py
@@ -9,6 +9,7 @@
     :copyright: (c) 2017 by Ashley Sommer (based on flask-cors by Cory Dolphin).
     :license: MIT, see LICENSE for more details.
 """
+import asyncio
 from functools import update_wrapper
 from .core import *
 


### PR DESCRIPTION
I was under the impression that Sanic-Cors (when using the decorator) worked fine for async handler functions. Turns out I didn't test that part when porting from Flask-Cors. Luckily @MarSoft found and fixed it.