### PR TITLE
Do not use CIDict for headers dict

### DIFF
--- a/sanic_cors/core.py
+++ b/sanic_cors/core.py
@@ -240,15 +240,8 @@ def set_cors_headers(req, resp, context, options):
     if resp is None:
         return None
 
-    # Some libraries, like OAuthlib, set resp.headers to non Multidict
-    # objects (Werkzeug Headers work as well). This is a problem because
-    # headers allow repeated values.
-    # TODO: In sanic, the CIDict is _not_ a multidict.
-    if not isinstance(resp.headers, CIDict):
-        # FYI this has the added (bonus) side-effect that if resp.headers is None
-        # (response headers can be None on websocket responses for example)
-        # Then CIDict(None) actually creates an empty headers dict, that is correct in this situation.
-        resp.headers = CIDict(resp.headers)
+    if resp.headers is None:
+        resp.headers = {}
 
     headers_to_set = get_cors_headers(options, req.headers, req.method)
 


### PR DESCRIPTION
Hello, 
it seems replacing `headers` of a `Response` with `CIDict` instance breaks sanic. `CIDict` expects all keys to be instances of `str` (it is calling `casefold()` on them), but when dealing with cookies, sanic uses `MultiHeader` as a key (see [sanic/cookies.py:59](https://github.com/channelcat/sanic/blob/6cf320bedb76edc5d30378bf03a294f65de95929/sanic/cookies.py#L59).

I am not sure of all the consequences of this change as I just started using sanic-cors, but tests are passing and everything seems to work. 
Can you please review it and propose a proper solution?