### PR TITLE
Fix support for latest sanic

### DIFF
--- a/sanic_cors/core.py
+++ b/sanic_cors/core.py
@@ -11,7 +11,10 @@ import re
 import logging
 import collections
 from datetime import timedelta
-from sanic.server import CIDict
+try:
+    from sanic.server import CIDict
+except ImportError:
+    from sanic.server import CIMultiDict as CIDict
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
Due to the change on https://github.com/channelcat/sanic/commit/334649dfd4e9b16cbcadcc6264ac9dee6ab7baf3#diff-bd84a6e523017a7f3d6bd72ee689dce2L42, sanic-cors is broken.

The fix is as simple as try-excepting the imports so that the right thing can be imported, which is exactly what this PR does.

All credit of this PR goes to @lnmds, as she was the one to write the fix. I'm just submitting this on her behalf as she's busy.