### PR TITLE
Fix warning in collections.Iterable

### DIFF
--- a/sanic_cors/core.py
+++ b/sanic_cors/core.py
@@ -81,7 +81,7 @@ def parse_resources(resources):
     elif isinstance(resources, str):
         return [(re_fix(resources), {})]
 
-    elif isinstance(resources, collections.Iterable):
+    elif isinstance(resources, collections.abc.Iterable):
         return [(re_fix(r), {}) for r in resources]
 
     # Type of compiled regex is not part of the public API. Test for this
@@ -336,7 +336,7 @@ def flexible_str(obj):
     if obj is None:
         return None
     elif(not isinstance(obj, str)
-            and isinstance(obj, collections.Iterable)):
+            and isinstance(obj, collections.abc.Iterable)):
         return ', '.join(str(item) for item in sorted(obj))
     else:
         return str(obj)
@@ -354,7 +354,7 @@ def ensure_iterable(inst):
     """
     if isinstance(inst, str):
         return [inst]
-    elif not isinstance(inst, collections.Iterable):
+    elif not isinstance(inst, collections.abc.Iterable):
         return [inst]
     else:
         return inst


### PR DESCRIPTION
Use `collections.abc.Iterable` instead of `collections.Iterable`.

```
tests/core/test_override_headers.py::ResponseHeadersOverrideTestCaseIntegration::test_override_headers
  /root/sanic-cors/sanic_cors/core.py:339: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    and isinstance(obj, collections.Iterable)):
```

From https://docs.python.org/3/whatsnew/3.7.html#id3

> In Python 3.8, the abstract base classes in collections.abc will no longer be exposed in the regular collections module. This will help create a clearer distinction between the concrete classes and the abstract base classes. (Contributed by Serhiy Storchaka in bpo-25988.)

`collections.abc` was introduced in Python 3.3,  and sanic only support Python3.5+. I think it will be ok.