### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/tests/core/helper_tests.py
+++ b/tests/core/helper_tests.py
@@ -24,10 +24,10 @@ class InternalsTestCase(unittest.TestCase):
         self.assertTrue(try_match('www.com/foo', 'www.com/fo*'))
 
     def test_flexible_str_str(self):
-        self.assertEquals(flexible_str('Bar, Foo, Qux'), 'Bar, Foo, Qux')
+        self.assertEqual(flexible_str('Bar, Foo, Qux'), 'Bar, Foo, Qux')
 
     def test_flexible_str_set(self):
-        self.assertEquals(flexible_str(set(['Foo', 'Bar', 'Qux'])),
+        self.assertEqual(flexible_str(set(['Foo', 'Bar', 'Qux'])),
                           'Bar, Foo, Qux')
 
     def test_serialize_options(self):
@@ -45,14 +45,14 @@ class InternalsTestCase(unittest.TestCase):
     def test_get_allow_headers_empty(self):
         options = serialize_options({'allow_headers': r'*'})
 
-        self.assertEquals(get_allow_headers(options, ''), None)
-        self.assertEquals(get_allow_headers(options, None), None)
+        self.assertEqual(get_allow_headers(options, ''), None)
+        self.assertEqual(get_allow_headers(options, None), None)
 
     def test_get_allow_headers_matching(self):
         options = serialize_options({'allow_headers': r'*'})
 
-        self.assertEquals(get_allow_headers(options, 'X-FOO'), 'X-FOO')
-        self.assertEquals(
+        self.assertEqual(get_allow_headers(options, 'X-FOO'), 'X-FOO')
+        self.assertEqual(
             get_allow_headers(options, 'X-Foo, X-Bar'),
             'X-Bar, X-Foo'
         )
@@ -60,9 +60,9 @@ class InternalsTestCase(unittest.TestCase):
     def test_get_allow_headers_matching_none(self):
         options = serialize_options({'allow_headers': r'X-SANIC-.*'})
 
-        self.assertEquals(get_allow_headers(options, 'X-SANIC-CORS'),
+        self.assertEqual(get_allow_headers(options, 'X-SANIC-CORS'),
                           'X-SANIC-CORS')
-        self.assertEquals(
+        self.assertEqual(
             get_allow_headers(options, 'X-NOT-SANIC-CORS'),
             ''
         )

--- a/tests/decorator/test_credentials.py
+++ b/tests/decorator/test_credentials.py
@@ -41,7 +41,7 @@ class SupportsCredentialsCase(SanicCorsTestCase):
             Access-Control-Allow-Credentials header.
         '''
         resp = self.get('/test_credentials_supported', origin='www.example.com')
-        self.assertEquals(resp.headers.get(ACL_CREDENTIALS), 'true')
+        self.assertEqual(resp.headers.get(ACL_CREDENTIALS), 'true')
 
     def test_default(self):
         ''' The default behavior should be to disallow credentials.

--- a/tests/decorator/test_origins.py
+++ b/tests/decorator/test_origins.py
@@ -191,7 +191,7 @@ class OriginsTestCase(SanicCorsTestCase):
                                             origin=domain):
                 self.assertEqual(domain, resp.headers.get(ACL_ORIGIN))
 
-        self.assertEquals("http://example.com",
+        self.assertEqual("http://example.com",
             self.get('/test_regex_mixed_list', origin='http://example.com').headers.get(ACL_ORIGIN))
 
     def test_multiple_protocols(self):

--- a/tests/extension/test_app_extension.py
+++ b/tests/extension/test_app_extension.py
@@ -179,7 +179,7 @@ class AppExtensionRegexp(SanicCorsTestCase):
                                             origin=domain):
                 self.assertEqual(domain, resp.headers.get(ACL_ORIGIN))
 
-        self.assertEquals("http://example.com",
+        self.assertEqual("http://example.com",
             self.get('/test_regex_mixed_list', origin='http://example.com').headers.get(ACL_ORIGIN))
 
 


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268