### PR TITLE
Anchor origin regex matching to fix CORS allowlist bypass (CVE-2026-37737)

### DIFF
--- a/sanic_cors/core.py
+++ b/sanic_cors/core.py
@@ -303,9 +303,9 @@ def try_match_any(inst, patterns):
 def try_match(request_origin, maybe_regex):
     """Safely attempts to match a pattern or string to a request origin."""
     if isinstance(maybe_regex, RegexObject):
-        return re.match(maybe_regex, request_origin)
+        return re.fullmatch(maybe_regex, request_origin)
     elif probably_regex(maybe_regex):
-        return re.match(maybe_regex, request_origin, flags=re.IGNORECASE)
+        return re.fullmatch(maybe_regex, request_origin, flags=re.IGNORECASE)
     else:
         try:
             return request_origin.lower() == maybe_regex.lower()

--- a/tests/test_cve_2026_37737.py
+++ b/tests/test_cve_2026_37737.py
@@ -1,0 +1,48 @@
+"""
+Regression test for CVE-2026-37737.
+
+sanic-cors <= 2.2.0 matched the request Origin against configured regex
+origins using re.match(), which is not end-anchored. A pattern intended to
+match exactly "https://trusted.com" therefore also matched any origin that
+merely *began* with that string (e.g. "https://trusted.com.attacker.io"),
+allowing the attacker origin to be reflected in Access-Control-Allow-Origin.
+
+These tests assert that legitimate origins still match while suffix-appended
+and trailing-variant origins do not.
+"""
+
+import re
+
+from sanic_cors.core import try_match
+
+
+def test_regex_origin_is_end_anchored():
+    # Contains a backslash, so it is treated as a regex by try_match.
+    pattern = r'https://trusted\.com'
+
+    # Legitimate, exact origin still matches.
+    assert try_match('https://trusted.com', pattern)
+
+    # CVE-2026-37737: a domain that begins with the trusted string but has an
+    # attacker-controlled suffix must NOT match.
+    assert not try_match('https://trusted.com.attacker.io', pattern)
+
+    # A trailing variation such as an added port must NOT match this pattern.
+    assert not try_match('https://trusted.com:8080', pattern)
+
+
+def test_compiled_regex_origin_is_end_anchored():
+    pattern = re.compile(r'https://.*\.example\.com')
+
+    # Legitimate subdomain still matches.
+    assert try_match('https://app.example.com', pattern)
+
+    # Suffix-appended attacker origin must NOT match.
+    assert not try_match('https://app.example.com.attacker.io', pattern)
+
+
+def test_plain_string_origin_unaffected():
+    # Plain strings use exact comparison and were never vulnerable; this just
+    # confirms the fix does not change that path.
+    assert try_match('https://trusted.com', 'https://trusted.com')
+    assert not try_match('https://trusted.com.attacker.io', 'https://trusted.com')


### PR DESCRIPTION
## Summary
`try_match()` matched the request `Origin` against configured regex origins
using `re.match()`, which only anchors at the start of the string. A configured
regex origin such as `https://trusted\.com` therefore also matched origins that
merely *begin* with the trusted value — e.g. `https://trusted.com.attacker.io`
or `https://trusted.com:8080`. The attacker origin is then reflected in
`Access-Control-Allow-Origin`, bypassing the allowlist. Tracked as CVE-2026-37737.

This affects only origins configured as regular expressions (or compiled
patterns). Plain-string origins use exact comparison and are unaffected.

### Fix
Replace `re.match()` with `re.fullmatch()` in `try_match()` so the pattern must
consume the entire origin string.

### Behavioral note
Configs that relied (likely unintentionally) on prefix matching — e.g. a regex
`https://example\.com` also matching `https://example.com:8080` — will no longer
match. This is the intended security tightening; express such cases explicitly,
e.g. `https://example\.com(:\d+)?`.

### Disclosure
Reported to the maintainer 2026-03-14. CVE-2026-37737 published 2026-06-05.
Advisory: https://github.com/npbhatter17/security-advisories/blob/main/CVE-2026-37737-sanic-cors-advisory.md